### PR TITLE
fallback to datetime if dateutil is not available

### DIFF
--- a/rest_gae/rest_gae.py
+++ b/rest_gae/rest_gae.py
@@ -22,10 +22,10 @@ from google.appengine.ext.webapp import blobstore_handlers
 from google.appengine.api import app_identity
 from google.net.proto.ProtocolBuffer import ProtocolBufferDecodeError
 
-#try:
-#    import dateutil.parser
-#except ImportError as e:
-dateutil = None
+try:
+    import dateutil.parser
+except ImportError as e:
+    dateutil = None
 
 
 # The REST permissions


### PR DESCRIPTION
We parse input dates and times in ISO 8601 format only

This means that a date, time, or datetime that is output from the API is also valid input, when we fallback to datetime.strptime.

Fixes #4
